### PR TITLE
fix: force CheckFailed msg arg to string

### DIFF
--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -18,12 +18,12 @@ from serialized_data_interface import (
 class CheckFailed(Exception):
     """ Raise this exception if one of the checks in main fails. """
 
-    def __init__(self, msg, status_type=None):
+    def __init__(self, msg: str, status_type=None):
         super().__init__()
 
-        self.msg = msg
+        self.msg = str(msg)
         self.status_type = status_type
-        self.status = status_type(msg)
+        self.status = status_type(self.msg)
 
 
 class Operator(CharmBase):


### PR DESCRIPTION
fixes error where non-string input will cause an exception when instantiating the `status`