### PR TITLE
Add min-juju-version element to prevent excess PVC creation

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -3,6 +3,7 @@
 name: tensorboard-controller
 description: Kubeflow Tensorboard Controller
 summary: Kubeflow Tensorboard Controller
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -3,6 +3,7 @@
 name: tensorboards-web-app
 summary: Kubeflow Tensorboards Web App
 description: Kubeflow Tensorboards Web App
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:


### PR DESCRIPTION
This PR addresses GH-425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.