### PR TITLE
Upgrade to v1.6

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -71,6 +71,7 @@ jobs:
             charmcraft-channel: latest/candidate
       - name: Run test
         run: |
+          sg microk8s -c "microk8s enable metallb:10.64.140.43-10.64.140.49"
           tox -e integration
 
       # TODO: Remove once the actions-operator does this automatically
@@ -82,6 +83,9 @@ jobs:
       - name: Get all
         run: kubectl get all -A
         if: failure()
+      - name: Get gateway
+        run: kubectl get gateway -A
+        if: failure()
       - name: Describe deployments
         run: kubectl describe deployments -A
         if: failure()
@@ -89,7 +93,7 @@ jobs:
         run: kubectl describe replicasets -A
         if: failure()
       - name: Get juju status
-        run: juju status
+        run: juju status --relations
         if: failure()
       - name: Get tensorboard-controller logs
         run: kubectl logs -n testing --tail 1000 -ljuju-app=tensorboard-controller

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 .tox/
 __pycache__
 *.charm
+.idea

--- a/charms/tensorboard-controller/files/crds.yaml
+++ b/charms/tensorboard-controller/files/crds.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: tensorboards.tensorboard.kubeflow.org
 spec:
@@ -15,70 +15,70 @@ spec:
     plural: tensorboards
     singular: tensorboard
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Tensorboard is the Schema for the tensorboards API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TensorboardSpec defines the desired state of Tensorboard
-          properties:
-            logspath:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "make" to regenerate code after modifying this file'
-              type: string
-          required:
-          - logspath
-          type: object
-        status:
-          description: TensorboardStatus defines the observed state of Tensorboard
-          properties:
-            conditions:
-              description: Conditions is an array of current conditions
-              items:
-                description: TensorboardCondition defines the observed state of Tensorboard
-                properties:
-                  deploymentState:
-                    description: Deployment status, 'Available', 'Progressing', 'ReplicaFailure'
-                      .
-                    type: string
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
-                    type: string
-                required:
-                - deploymentState
-                type: object
-              type: array
-            readyReplicas:
-              description: ReadyReplicas defines the number of Tensorboard Servers
-                that are available to connect. The value of ReadyReplicas can be either
-                0 or 1
-              format: int32
-              type: integer
-          required:
-          - conditions
-          - readyReplicas
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Tensorboard is the Schema for the tensorboards API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TensorboardSpec defines the desired state of Tensorboard
+            properties:
+              logspath:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file'
+                type: string
+            required:
+            - logspath
+            type: object
+          status:
+            description: TensorboardStatus defines the observed state of Tensorboard
+            properties:
+              conditions:
+                description: Conditions is an array of current conditions
+                items:
+                  description: TensorboardCondition defines the observed state of
+                    Tensorboard
+                  properties:
+                    deploymentState:
+                      description: Deployment status, 'Available', 'Progressing',
+                        'ReplicaFailure' .
+                      type: string
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                  required:
+                  - deploymentState
+                  type: object
+                type: array
+              readyReplicas:
+                description: ReadyReplicas defines the number of Tensorboard Servers
+                  that are available to connect. The value of ReadyReplicas can be
+                  either 0 or 1
+                format: int32
+                type: integer
+            required:
+            - conditions
+            - readyReplicas
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charms/tensorboard-controller/lib/charms/istio_pilot/v0/istio_gateway_name.py
+++ b/charms/tensorboard-controller/lib/charms/istio_pilot/v0/istio_gateway_name.py
@@ -1,0 +1,121 @@
+"""Library for sharing istio gateway information
+
+This library wraps the relation endpoints using the `istio-gateway-name`
+interface. It provides a Python API for both requesting and providing 
+gateway information.
+
+## Getting Started
+
+### Fetch library with charmcraft
+You can fetch the library using the following commands with charmcraft.
+```shell
+cd some-charm
+charmcraft fetch-lib charms.istio_pilot.v0.istio_gateway_name
+```
+### Add relation to metadata.yaml
+```yaml
+requires:
+    gateway:
+        interface: istio_gateway_name
+        limit: 1
+```
+
+### Initialise the library in charm.py
+```python
+from charms.istio_pilot.v0.istio_gateway_name import GatewayProvider, GatewayRelationError
+
+Class SomeCharm(CharmBase):
+    def __init__(self, *args):
+        self.gateway = GatewayProvider(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+
+    def some_event_function():
+        # use the getter function wherever the info is needed
+        try:
+            gateway_data = self.gateway_relation.get_relation_data()
+            except GatewayRelationError as error:
+            ...
+```
+"""
+
+import logging
+from ops.framework import Object
+from ops.model import Application
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+DEFAULT_RELATION_NAME = "gateway"
+DEFAULT_INTERFACE_NAME = "istio-gateway-name"
+
+logger = logging.getLogger(__name__)
+
+
+class GatewayRelationError(Exception):
+    pass
+
+
+class GatewayRelationMissingError(GatewayRelationError):
+    def __init__(self):
+        self.message = "Missing gateway relation with istio-pilot"
+        super().__init__(self.message)
+
+
+class GatewayRelationTooManyError(GatewayRelationError):
+    def __init__(self):
+        self.message = "Too many istio-gateway-name relations"
+        super().__init__(self.message)
+
+
+class GatewayRelationDataMissingError(GatewayRelationError):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class GatewayRequirer(Object):
+    def __init__(self, charm, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def get_relation_data(self):
+        if not self.model.unit.is_leader():
+            return
+        gateway = self.model.relations[self.relation_name]
+        if len(gateway) == 0:
+            raise GatewayRelationMissingError()
+        if len(gateway) > 1:
+            raise GatewayRelationTooManyError()
+
+        remote_app = [
+            app
+            for app in gateway[0].data.keys()
+            if isinstance(app, Application) and not app._is_our_app
+        ][0]
+
+        data = gateway[0].data[remote_app]
+
+        if not "gateway_name" in data:
+            logger.error(
+                "Missing gateway name in gateway relation data. Waiting for gateway creation in istio-pilot"
+            )
+            raise GatewayRelationDataMissingError(
+                "Missing gateway name in gateway relation data. Waiting for gateway creation in istio-pilot"
+            )
+
+        if not "gateway_namespace" in data:
+            logger.error("Missing gateway namespace in gateway relation data")
+            raise GatewayRelationDataMissingError(
+                "Missing gateway namespace in gateway relation data"
+            )
+
+        return {
+            "gateway_name": data["gateway_name"],
+            "gateway_namespace": data["gateway_namespace"],
+        }

--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -10,3 +10,7 @@ resources:
     type: oci-image
     description: OCI image for httpbin (kennethreitz/httpbin)
     upstream-source: kubeflownotebookswg/tensorboard-controller:v1.6.0-rc.0
+requires:
+  gateway:
+    interface: istio-gateway-name
+    limit: 1

--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -3,10 +3,10 @@
 name: tensorboard-controller
 description: Kubeflow Tensorboard Controller
 summary: Kubeflow Tensorboard Controller
-min-juju-version: "2.9.0"
+min-juju-version: "2.9.2"
 series: [kubernetes]
 resources:
   oci-image:
     type: oci-image
     description: OCI image for httpbin (kennethreitz/httpbin)
-    upstream-source: public.ecr.aws/j1r0q0g6/notebooks/tensorboard-controller:v1.4-rc.0
+    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.6.0-rc.0

--- a/charms/tensorboard-controller/src/charm.py
+++ b/charms/tensorboard-controller/src/charm.py
@@ -135,6 +135,10 @@ class Operator(CharmBase):
                         "command": ["/manager"],
                         # "args": ["--enable-leader-election"],
                         "ports": [{"name": "http", "containerPort": config["port"]}],
+                        "envConfig": {
+                            "ISTIO_GATEWAY": "kubeflow/kubeflow-gateway",
+                            "TENSORBOARD_IMAGE": "tensorflow/tensorflow:2.1.0",
+                        },
                     }
                 ],
             },

--- a/charms/tensorboard-controller/src/charm.py
+++ b/charms/tensorboard-controller/src/charm.py
@@ -86,10 +86,7 @@ class Operator(CharmBase):
                                     ],
                                 },
                                 {
-                                    "apiGroups": [
-                                        "networking.istio.io",
-                                        "networking.istio.io/v1alpha3",
-                                    ],
+                                    "apiGroups": ["networking.istio.io"],
                                     "resources": ["virtualservices"],
                                     "verbs": [
                                         "get",
@@ -118,6 +115,11 @@ class Operator(CharmBase):
                                     "verbs": ["get", "patch", "update"],
                                 },
                                 {
+                                    "apiGroups": ["tensorboard.kubeflow.org"],
+                                    "resources": ["tensorboards/finalizers"],
+                                    "verbs": ["update"],
+                                },
+                                {
                                     "apiGroups": ["storage.k8s.io"],
                                     "resources": ["storageclasses"],
                                     "verbs": ["get", "list", "watch"],
@@ -128,7 +130,7 @@ class Operator(CharmBase):
                 },
                 "containers": [
                     {
-                        "name": "controller-manager",
+                        "name": "deployment",
                         "imageDetails": image_details,
                         "command": ["/manager"],
                         # "args": ["--enable-leader-election"],

--- a/charms/tensorboard-controller/src/charm.py
+++ b/charms/tensorboard-controller/src/charm.py
@@ -18,9 +18,9 @@ class CheckFailed(Exception):
     def __init__(self, msg, status_type=None):
         super().__init__()
 
-        self.msg = msg
+        self.msg = str(msg)
         self.status_type = status_type
-        self.status = status_type(msg)
+        self.status = status_type(self.msg)
 
 
 class Operator(CharmBase):
@@ -86,7 +86,10 @@ class Operator(CharmBase):
                                     ],
                                 },
                                 {
-                                    "apiGroups": ["networking.istio.io"],
+                                    "apiGroups": [
+                                        "networking.istio.io",
+                                        "networking.istio.io/v1alpha3",
+                                    ],
                                     "resources": ["virtualservices"],
                                     "verbs": [
                                         "get",

--- a/charms/tensorboard-controller/tests/unit/test_charm.py
+++ b/charms/tensorboard-controller/tests/unit/test_charm.py
@@ -26,7 +26,7 @@ def test_missing_image(harness):
     assert isinstance(harness.charm.model.unit.status, BlockedStatus)
 
 
-def test_main(harness):
+def test_no_gateway_relation(harness):
     harness.set_leader(True)
     harness.add_oci_resource(
         "oci-image",
@@ -36,6 +36,30 @@ def test_main(harness):
             "password": "",
         },
     )
+    harness.begin_with_initial_hooks()
+    assert isinstance(harness.charm.model.unit.status, WaitingStatus)
+
+
+def test_main(harness):
+    harness.set_model_name("test-model")
+    harness.set_leader(True)
+    harness.add_oci_resource(
+        "oci-image",
+        {
+            "registrypath": "image",
+            "username": "",
+            "password": "",
+        },
+    )
+
+    rel_id = harness.add_relation("gateway", "app")
+    harness.update_relation_data(
+        rel_id,
+        "app",
+        {"gateway_namespace": "test-model", "gateway_name": "test-gateway"},
+    )
+    harness.add_relation_unit(rel_id, "app/0")
+
     harness.begin_with_initial_hooks()
     pod_spec = harness.get_pod_spec()
 

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app:v1.4-rc.0
+    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.6.0-rc.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
This PR upgrades tensorboard-controller and tensorboards-web-app to v1.6.
It updates manifest files and podspec to match latest release and points to the new images in `metadata.yaml`.
Starting from this release, istio gateway name is required as an environment variable in the podspec. `istio-pilot:gateway` relation was added to tensorboard-controller in order to ensure the pods get recreated when the gateway name is changed. Tests have been updated to cover these changes.
Both upgraded charms were deployed successfully on microk8s 1.21 and 1.22 and tested in a full bundle on 1.21.

In order to test these charms:
1. Deploy a bundle. An additional relation will be required:
`juju relate istio-pilot:gateway tensorboard-controller:gateway`
3. Connect to the dashboard.
4. Add a jupyter notebook server, upload and run an example [notebook](https://www.tensorflow.org/tensorboard/get_started).
5. Navigate to `Tensorboards`.
6. Add a new tensorboard: select PVC checkbox, select the notebook's PVC from the dropdown list and fill in the `Mount Path` field with `logs/fit` (or other path depending on the example used).
7. Click on create and wait for it to get active (usually up to 2 minutes).
8. Connect to the tensorboard.
If the creation was successful, a new virtual service with the tensorboard name should be created in the user’s namespace.