### PR TITLE
Update CI to test on microk8s 1.22

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
             provider: microk8s
-            channel: 1.21/stable
+            channel: 1.22/stable
             charmcraft-channel: latest/candidate
       - name: Run test
         run: |


### PR DESCRIPTION
This PR updates microk8s version in CI from 1.21 to 1.22.