### PR TITLE
feat: dynamic sidebar content

### DIFF
--- a/charms/tensorboards-web-app/config.yaml
+++ b/charms/tensorboards-web-app/config.yaml
@@ -14,3 +14,15 @@ options:
     type: boolean
     default: false
     description: Whether cookies should require HTTPS
+  sidebar-text:
+    type: string
+    default: Tensorboards
+    description: Label text in dashboard sidebar
+  sidebar-icon:
+    type: string
+    default: assessment
+    description: Icon name to be used in dashboard sidebar
+  sidebar-link:
+    type: string
+    default: /tensorboards/
+    description: Url path associated with the sidebar element

--- a/charms/tensorboards-web-app/config.yaml
+++ b/charms/tensorboards-web-app/config.yaml
@@ -14,15 +14,4 @@ options:
     type: boolean
     default: false
     description: Whether cookies should require HTTPS
-  sidebar-text:
-    type: string
-    default: Tensorboards
-    description: Label text in dashboard sidebar
-  sidebar-icon:
-    type: string
-    default: assessment
-    description: Icon name to be used in dashboard sidebar
-  sidebar-link:
-    type: string
-    default: /tensorboards/
-    description: Url path associated with the sidebar element
+

--- a/charms/tensorboards-web-app/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_sidebar.py
+++ b/charms/tensorboards-web-app/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_sidebar.py
@@ -1,0 +1,129 @@
+"""# KubeflowDashboardSidebar Library
+This library is designated to ease the process of adding the componentes 
+to the UI sidebar of Kubeflow dashboard. The sidbar is dynamic and allows 
+to add and remove items based on the configmap content.
+
+In order to add an item to the library `sidebar` relation needs to be established
+between the application which is going to be added and the kubeflow dashboard application.
+At the joining event the joning application needs to send a json containing the sidebar element
+details. Charm using this library is expected to provide these details on initialization.
+These details are send through relation data.
+
+These are the required fields:
+- **type**: type of the sidebar element (only `item` option is allowed)
+- **link**: relative path to the place of redirection.
+- **text**: text of the displayed sidebar element
+- **icon**: icon of the sidebar element
+
+Bellow is the example (for tensorboards application) of json body. Remember list of configuration
+is expected so one or many sidebars can be added at the same time:
+```
+{
+    "position": 3,
+    "type": "item",
+    "link": "/tensorboards/",
+    "text": "Tensorboards",
+    "icon": "assessment",
+}
+```
+
+In oder to remove the item from the sidebar `sidebar` relation needs to be removed.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.kubeflow_dashboard.v0.kubeflow_dashboard_sidebar
+```
+
+Then, to initialise the library:
+
+```python
+from charms.kubeflow_dashboard.v0.kubeflow_dashboard_sidebar import (
+    KubeflowDashboardSidebar,
+)
+# ...
+
+SIDEBAR_LINK = [
+    {
+        "position": 4,
+        "type": "item",
+        "link": "/tensorboards/",
+        "text": "Tensorboards",
+        "icon": "assessment",
+    }
+] # list of items must be provided
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.kubeflow_dashboard_sidebar = KubeflowDashboardSidebar(self, SIDEBAR_LINK)
+    # ...
+```
+"""
+
+import json
+import logging
+
+from typing import Dict
+from ops.charm import CharmBase, RelationJoinedEvent, RelationDepartedEvent
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a5795a88ee31458f9bc3ae026a04b89f"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class KubeflowDashboardSidebar(Object):
+    def __init__(
+        self,
+        charm: CharmBase,
+        sidebar_link: Dict,
+    ):
+        """Constructor for KubernetesServicePatch.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            sidebar_link: dictionary specifying the elemnt of the sidebar to be added.
+        """
+        super().__init__(charm, None)
+        self.charm = charm
+        self.sidebar_link = sidebar_link
+        self.framework.observe(
+            self.charm.on.sidebar_relation_joined,
+            self._on_sidebar_relation_joined,
+        )
+        self.framework.observe(
+            self.charm.on.sidebar_relation_departed,
+            self._on_sidebar_relation_departed,
+        )
+
+    def _on_sidebar_relation_joined(self, event: RelationJoinedEvent):
+        """Send the confing  on relation joined
+
+        Args:
+            event: relation joined object
+        """
+        if not self.charm.unit.is_leader():
+            return
+        event.relation.data[self.charm.app].update({"config": json.dumps(self.sidebar_link)})
+
+    def _on_sidebar_relation_departed(self, event: RelationDepartedEvent):
+        """Remove the confing  on relation departed
+
+        Args:
+            event: relation departed object
+        """
+        if not self.charm.unit.is_leader():
+            return
+        event.relation.data[self.charm.app].update({"config": json.dumps([])})

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -17,6 +17,6 @@ requires:
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
     versions: [v1]
 provides:
-  sidepanel:
-    interface: sidepanel
+  sidebar:
+    interface: sidebar
     optional: true

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -16,3 +16,7 @@ requires:
     interface: ingress
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
     versions: [v1]
+provides:
+  sidepanel:
+    interface: sidepanel
+    optional: true

--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -140,13 +140,15 @@ class Operator(CharmBase):
         event.relation.data[self.app].update(
             {
                 "config": json.dumps(
-                    {
-                        "app": self.app.name,
-                        "type": "item",
-                        "link": self.model.config["sidebar-link"],
-                        "text": self.model.config["sidebar-text"],
-                        "icon": self.model.config["sidebar-icon"],
-                    }
+                    [
+                        {
+                            "app": self.app.name,
+                            "type": "item",
+                            "link": "/tensorboards/",
+                            "text": "Tensorboards",
+                            "icon": "assessment",
+                        }
+                    ]
                 )
             }
         )

--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -42,7 +42,12 @@ class Operator(CharmBase):
         ]:
             self.framework.observe(event, self.main)
         self.framework.observe(
-            self.on.sidebar_relation_joined, self._on_sidebar_relation_joined
+            self.on.sidebar_relation_joined,
+            self._on_sidebar_relation_joined,
+        )
+        self.framework.observe(
+            self.on.sidebar_relation_departed,
+            self._on_sidebar_relation_departed,
         )
 
     def main(self, event):
@@ -143,6 +148,7 @@ class Operator(CharmBase):
                     [
                         {
                             "app": self.app.name,
+                            "position": 4,
                             "type": "item",
                             "link": "/tensorboards/",
                             "text": "Tensorboards",
@@ -152,6 +158,11 @@ class Operator(CharmBase):
                 )
             }
         )
+
+    def _on_sidebar_relation_departed(self, event):
+        if not self.unit.is_leader():
+            return
+        event.relation.data[self.app].update({"config": json.dumps([])})
 
     def _check_leader(self):
         if not self.unit.is_leader():

--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -2,11 +2,13 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
 import logging
 
+from charms.kubeflow_dashboard.v0.kubeflow_dashboard_sidebar import (
+    KubeflowDashboardSidebar,
+)
 from oci_image import OCIImageResource, OCIImageResourceError
-from ops.charm import CharmBase, RelationJoinedEvent
+from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from serialized_data_interface import (
@@ -14,6 +16,16 @@ from serialized_data_interface import (
     NoVersionsListed,
     get_interfaces,
 )
+
+SIDEBAR_LINK = [
+    {
+        "position": 4,
+        "type": "item",
+        "link": "/tensorboards/",
+        "text": "Tensorboards",
+        "icon": "assessment",
+    }
+]
 
 
 class CheckFailed(Exception):
@@ -33,6 +45,7 @@ class Operator(CharmBase):
 
         self.log = logging.getLogger(__name__)
         self.image = OCIImageResource(self, "oci-image")
+        self.kubeflow_dashboard_sidebar = KubeflowDashboardSidebar(self, SIDEBAR_LINK)
 
         for event in [
             self.on.install,
@@ -42,14 +55,6 @@ class Operator(CharmBase):
             self.on["ingress"].relation_changed,
         ]:
             self.framework.observe(event, self.main)
-        self.framework.observe(
-            self.on.sidebar_relation_joined,
-            self._on_sidebar_relation_joined,
-        )
-        self.framework.observe(
-            self.on.sidebar_relation_departed,
-            self._on_sidebar_relation_departed,
-        )
 
     def main(self, event):
         try:
@@ -139,31 +144,6 @@ class Operator(CharmBase):
                     "port": self.model.config["port"],
                 }
             )
-
-    def _on_sidebar_relation_joined(self, event: RelationJoinedEvent):
-        if not self.unit.is_leader():
-            return
-        event.relation.data[self.app].update(
-            {
-                "config": json.dumps(
-                    [
-                        {
-                            "app": self.app.name,
-                            "position": 4,
-                            "type": "item",
-                            "link": "/tensorboards/",
-                            "text": "Tensorboards",
-                            "icon": "assessment",
-                        }
-                    ]
-                )
-            }
-        )
-
-    def _on_sidebar_relation_departed(self, event):
-        if not self.unit.is_leader():
-            return
-        event.relation.data[self.app].update({"config": json.dumps([])})
 
     def _check_leader(self):
         if not self.unit.is_leader():

--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -50,9 +50,7 @@ async def test_build_and_deploy_with_relations(ops_test: OpsTest):
         istio_pilot,
         istio_gateway,
     )
-    await ops_test.model.add_relation(
-        f"{istio_pilot}:gateway-info:", f"{tc_app_name}:gateway-info:"
-    )
+    await ops_test.model.add_relation(f"{istio_pilot}:gateway-info", f"{tc_app_name}:gateway-info")
 
     image_path = TWA_METADATA["resources"]["oci-image"]["upstream-source"]
     resources = {"oci-image": image_path}

--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -7,8 +7,12 @@ from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
 
-TC_METADATA = yaml.safe_load(Path("charms/tensorboard-controller/metadata.yaml").read_text())
-TWA_METADATA = yaml.safe_load(Path("charms/tensorboards-web-app/metadata.yaml").read_text())
+TC_METADATA = yaml.safe_load(
+    Path("charms/tensorboard-controller/metadata.yaml").read_text()
+)
+TWA_METADATA = yaml.safe_load(
+    Path("charms/tensorboards-web-app/metadata.yaml").read_text()
+)
 
 
 @pytest.mark.abort_on_fail
@@ -46,7 +50,9 @@ async def test_build_and_deploy_with_relations(ops_test: OpsTest):
         istio_pilot,
         istio_gateway,
     )
-    await ops_test.model.add_relation(f"{istio_pilot}:gateway", f"{tc_app_name}:gateway")
+    await ops_test.model.add_relation(
+        f"{istio_pilot}:gateway-info:", f"{tc_app_name}:gateway-info:"
+    )
 
     image_path = TWA_METADATA["resources"]["oci-image"]["upstream-source"]
     resources = {"oci-image": image_path}


### PR DESCRIPTION
Related to this [jira task](https://warthogs.atlassian.net/browse/KF-567?atlOrigin=eyJpIjoiN2M3MjQwZmY2NzEwNGQwMTkzYThkZTNhMzU0YmFlNmUiLCJwIjoiaiJ9) and this [feature](https://github.com/canonical/kubeflow-dashboard-operator/issues/8)

In `kubeflow-dashboard-operator` there is a `sidebar` relation. In order to add element to the sidebar proper relation needs to be established. After the relation is set, charms fills the config for given app-name.

Sidebar element is removed after the relation is broken.