### PR TITLE
Observe leader-elected event

### DIFF
--- a/charms/tensorboard-controller/tests/unit/test_charm.py
+++ b/charms/tensorboard-controller/tests/unit/test_charm.py
@@ -20,6 +20,12 @@ def test_not_leader(harness):
     assert isinstance(harness.charm.model.unit.status, WaitingStatus)
 
 
+def test_leader_elected(harness):
+    harness.begin_with_initial_hooks()
+    harness.set_leader(True)
+    assert not isinstance(harness.charm.model.unit.status, WaitingStatus)
+
+
 def test_missing_image(harness):
     harness.set_leader(True)
     harness.begin_with_initial_hooks()

--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -37,6 +37,7 @@ class Operator(CharmBase):
             self.on.install,
             self.on.upgrade_charm,
             self.on.config_changed,
+            self.on.leader_elected,
             self.on["ingress"].relation_changed,
         ]:
             self.framework.observe(event, self.main)

--- a/charms/tensorboards-web-app/tests/test_operator.py
+++ b/charms/tensorboards-web-app/tests/test_operator.py
@@ -17,6 +17,12 @@ def test_not_leader(harness):
     assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
 
 
+def test_leader_elected(harness):
+    harness.begin_with_initial_hooks()
+    harness.set_leader(True)
+    assert harness.charm.model.unit.status != WaitingStatus("Waiting for leadership")
+
+
 def test_missing_image(harness):
     harness.set_leader(True)
     harness.begin_with_initial_hooks()


### PR DESCRIPTION
When we use `juju upgrade-charm`, a new non-leader unit gets created, then the old still-leader one gets removed, resulting in the new unit being elected as the leader.
When the `leader_elected` event is not observed, the charm is not aware of having a leader now, so it remains stuck with message 'Waiting for leadership'.
This PR adds a fix to observe this event in tensorboards-web-app.