### PR TITLE
refactor: rename gateway relation and gateway name interface

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -11,6 +11,6 @@ resources:
     description: OCI image for httpbin (kennethreitz/httpbin)
     upstream-source: kubeflownotebookswg/tensorboard-controller:v1.6.0-rc.1
 requires:
-  gateway:
-    interface: istio-gateway-name
+  gateway-info:
+    interface: istio-gateway-info
     limit: 1

--- a/charms/tensorboard-controller/src/charm.py
+++ b/charms/tensorboard-controller/src/charm.py
@@ -10,7 +10,7 @@ from oci_image import OCIImageResource, OCIImageResourceError
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
-from charms.istio_pilot.v0.istio_gateway_name import (
+from charms.istio_pilot.v0.istio_gateway_info import (
     GatewayRequirer,
     GatewayRelationError,
 )
@@ -40,7 +40,7 @@ class Operator(CharmBase):
             self.on.leader_elected,
             self.on.upgrade_charm,
             self.on.config_changed,
-            self.on["gateway"].relation_changed,
+            self.on["gateway-info"].relation_changed,
         ]:
             self.framework.observe(event, self.main)
 
@@ -58,7 +58,7 @@ class Operator(CharmBase):
         try:
             gateway_data = self.gateway.get_relation_data()
         except GatewayRelationError:
-            self.model.unit.status = WaitingStatus("Waiting for gateway relation")
+            self.model.unit.status = WaitingStatus("Waiting for gateway info relation")
             return
 
         gateway_ns = gateway_data["gateway_namespace"]

--- a/charms/tensorboard-controller/tests/unit/test_charm.py
+++ b/charms/tensorboard-controller/tests/unit/test_charm.py
@@ -32,7 +32,7 @@ def test_missing_image(harness):
     assert isinstance(harness.charm.model.unit.status, BlockedStatus)
 
 
-def test_no_gateway_relation(harness):
+def test_no_gateway_info_relation(harness):
     harness.set_leader(True)
     harness.add_oci_resource(
         "oci-image",
@@ -58,7 +58,7 @@ def test_main(harness):
         },
     )
 
-    rel_id = harness.add_relation("gateway", "app")
+    rel_id = harness.add_relation("gateway-info", "app")
     harness.update_relation_data(
         rel_id,
         "app",


### PR DESCRIPTION
Please note this PR depends on the changes that [PR#112](https://github.com/canonical/istio-operators/pull/112) introduces, and thus should not be merged before that one. Also note we need to `charmcraft fetch-lib` before merging this PR.