### PR TITLE
chore: oci image version bump 1.6.0-rc.2 -> 1.6.0

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for httpbin (kennethreitz/httpbin)
-    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.6.0-rc.2
+    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.6.0
 requires:
   gateway-info:
     interface: istio-gateway-info

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.6.0-rc.2
+    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.6.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Version bump to 1.6.0 release image

NOTE: this PR depends on the latest image tag specified in [kubeflow/manifests](https://github.com/kubeflow/manifests/blob/v1.6-branch/apps/admission-webhook/upstream