### PR TITLE
Upgrade images and web-app manifests 1.7.0-rc.1

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for httpbin (kennethreitz/httpbin)
-    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.7.0-rc.0
+    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.7.0-rc.1
 requires:
   gateway-info:
     interface: istio-gateway-info

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.7.0-rc.0
+    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.7.0-rc.1
 requires:
   ingress:
     interface: ingress

--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -93,6 +93,11 @@ class Operator(CharmBase):
                                     "resources": ["storageclasses"],
                                     "verbs": ["get", "list", "watch"],
                                 },
+                                {
+                                    "apiGroups": ["kubeflow.org"],
+                                    "resources": ["poddefaults"],
+                                    "verbs": ["get", "list", "watch"],
+                                },
                             ],
                         }
                     ]


### PR DESCRIPTION
- bump tensorboard-controller image to 1.7.0-rc.1
- bump tensorboards-web-app image to 1.7.0-rc.1
- upgrade tensorboards-web-app roles in podspec to 1.7.0-rc.1