### PR TITLE
feat: bump tensorboards charms images to 1.8.0-rc.0

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   tensorboard-controller-image:
     type: oci-image
     description: OCI image for Tensorboard Controller
-    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.7.0
+    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.8.0-rc.0
 requires:
   gateway-info:
     interface: istio-gateway-info

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for Tensorboards Web App
     auto-fetch: true
-    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.7.0
+    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.8.0-rc.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Update `tensorboard-controller` and `tensorboards-web-app` images version to `v1.8.0-rc.0` in preparation for the 1.8 release
Based on kubeflow/manifests repo tag `v1.8.0-rc.0`.

No changes were observed for the manifests and CRDs.