### PR TITLE
pin integration test dependencies, refactor constants in tests for `track/1.8`

### DIFF
--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -5,27 +5,27 @@
 """A Juju Charm for Tensorboards Web App."""
 
 import logging
-from typing import Dict
 from pathlib import Path
-import yaml
+from typing import Dict
 
+import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
-from charms.kubeflow_dashboard.v0.kubeflow_dashboard_links import (
-    DashboardLink,
-    KubeflowDashboardLinksRequirer,
-)
 from charmed_kubeflow_chisme.kubernetes import (
     KubernetesResourceHandler,
     create_charm_default_labels,
 )
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charmed_kubeflow_chisme.pebble import update_layer
+from charms.kubeflow_dashboard.v0.kubeflow_dashboard_links import (
+    DashboardLink,
+    KubeflowDashboardLinksRequirer,
+)
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from lightkube import ApiError
 from lightkube.generic_resource import load_in_cluster_generic_resources
 from lightkube.models.core_v1 import ServicePort
-from lightkube.resources.rbac_authorization_v1 import ClusterRole, ClusterRoleBinding
 from lightkube.resources.core_v1 import ServiceAccount
+from lightkube.resources.rbac_authorization_v1 import ClusterRole, ClusterRoleBinding
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Container, MaintenanceStatus, WaitingStatus

--- a/charms/tensorboards-web-app/tests/integration/test_charm.py
+++ b/charms/tensorboards-web-app/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ ISTIO_GATEWAY = "istio-gateway"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
 ISTIO_GATEWAY_TRUST = True
 
+
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build and deploy the charm under test.
@@ -84,10 +85,10 @@ async def setup_istio(ops_test: OpsTest):
         config={"default-gateway": "test-gateway"},
         trust=ISTIO_PILOT_TRUST,
     )
-    await ops_test.model.add_relation(ISTIO_PILOT, ISTIO_GATEWAY)
+    await ops_test.model.add_relation(ISTIO_PILOT, ISTIO_GATEWAY_APP_NAME)
 
     await ops_test.model.wait_for_idle(
-        apps=[ISTIO_PILOT, ISTIO_GATEWAY],
+        apps=[ISTIO_PILOT, ISTIO_GATEWAY_APP_NAME],
         status="active",
         timeout=60 * 5,
     )

--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -48,7 +48,7 @@ async def test_build_and_deploy_with_relations(ops_test: OpsTest):
         config={"default-gateway": "test-gateway"},
         trust=ISTIO_PILOT_TRUST,
     )
-    await ops_test.model.add_relation(ISTIO_PILOT, ISTIO_GATEWAY)
+    await ops_test.model.add_relation(ISTIO_PILOT, ISTIO_GATEWAY_APP_NAME)
 
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:gateway-info", f"{tc_app_name}:gateway-info")
 

--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -10,6 +10,13 @@ log = logging.getLogger(__name__)
 TC_METADATA = yaml.safe_load(Path("charms/tensorboard-controller/metadata.yaml").read_text())
 TWA_METADATA = yaml.safe_load(Path("charms/tensorboards-web-app/metadata.yaml").read_text())
 
+ISTIO_CHANNEL = "1.17/stable"
+ISTIO_PILOT = "istio-pilot"
+ISTIO_PILOT_TRUST = True
+ISTIO_GATEWAY = "istio-gateway"
+ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
+ISTIO_GATEWAY_TRUST = True
+
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy_with_relations(ops_test: OpsTest):
@@ -25,30 +32,25 @@ async def test_build_and_deploy_with_relations(ops_test: OpsTest):
         trust=True,
     )
 
-    istio_gateway = "istio-ingressgateway"
-    istio_pilot = "istio-pilot"
     tc_app_name = TC_METADATA["name"]
     twa_name = TWA_METADATA["name"]
 
     await ops_test.model.deploy(
-        entity_url="istio-gateway",
-        application_name=istio_gateway,
-        channel="latest/edge",
+        ISTIO_GATEWAY,
+        application_name=ISTIO_GATEWAY_APP_NAME,
+        channel=ISTIO_CHANNEL,
         config={"kind": "ingress"},
-        trust=True,
+        trust=ISTIO_GATEWAY_TRUST,
     )
     await ops_test.model.deploy(
-        istio_pilot,
-        channel="latest/edge",
+        ISTIO_PILOT,
+        channel=ISTIO_CHANNEL,
         config={"default-gateway": "test-gateway"},
-        trust=True,
+        trust=ISTIO_PILOT_TRUST,
     )
+    await ops_test.model.add_relation(ISTIO_PILOT, ISTIO_GATEWAY)
 
-    await ops_test.model.add_relation(
-        istio_pilot,
-        istio_gateway,
-    )
-    await ops_test.model.add_relation(f"{istio_pilot}:gateway-info", f"{tc_app_name}:gateway-info")
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:gateway-info", f"{tc_app_name}:gateway-info")
 
     image_path = TWA_METADATA["resources"]["tensorboards-web-app-image"]["upstream-source"]
     resources = {"tensorboards-web-app-image": image_path}
@@ -59,7 +61,7 @@ async def test_build_and_deploy_with_relations(ops_test: OpsTest):
         trust=True,
     )
 
-    await ops_test.model.add_relation(f"{istio_pilot}:ingress", f"{twa_name}:ingress")
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{twa_name}:ingress")
 
     # Wait for everything to deploy
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 5)


### PR DESCRIPTION
Pins dependencies in the integration tests to their corresponding channels for this release.

Ref: https://github.com/canonical/bundle-kubeflow/issues/866
