### PR TITLE
Update manifests to v1.19.0

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   tensorboard-controller-image:
     type: oci-image
     description: OCI image for Tensorboard Controller
-    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.8.0
+    upstream-source: kubeflownotebookswg/tensorboard-controller:v1.9.0-rc.0
 requires:
   gateway-info:
     interface: istio-gateway-info

--- a/charms/tensorboard-controller/src/charm.py
+++ b/charms/tensorboard-controller/src/charm.py
@@ -36,7 +36,7 @@ CRD_RESOURCES = {
     "scope": "tensorboard",
 }
 
-TENSORBOARD_IMAGE = "tensorflow/tensorflow:2.1.0"
+TENSORBOARD_IMAGE = "tensorflow/tensorflow:2.5.1"
 
 
 class TensorboardController(CharmBase):
@@ -114,6 +114,7 @@ class TensorboardController(CharmBase):
         gateway_ns, gateway_name = self._get_gateway_data()
         ret_env_vars = {
             "ISTIO_GATEWAY": f"{gateway_ns}/{gateway_name}",
+            "ISTIO_HOST": "*",
             "TENSORBOARD_IMAGE": TENSORBOARD_IMAGE,
         }
 

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for Tensorboards Web App
     auto-fetch: true
-    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.8.0
+    upstream-source: kubeflownotebookswg/tensorboards-web-app:v1.9.0-rc.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Closes: https://github.com/canonical/pvcviewer-operator/issues/36

**Web-app**
I Generated manifests from this folder https://github.com/kubeflow/kubeflow/tree/master/components/crud-web-apps/tensorboards/manifests/overlays/istio for tag `v1.8.0` and `v1.9.0-rc.0`

**Controller**
I Generated manifests from this folder https://github.com/kubeflow/kubeflow/tree/master/components/tensorboard-controller/config/overlays/kubeflow for tag `v1.8.0` and `v1.9.0-rc.0`

Changes:
- one environment
- new images
- I have also changed the tensorboard image as it was not changed for long time.