### PR TITLE
Update dashboard link

### DIFF
--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -77,7 +77,7 @@ class TensorboardsWebApp(CharmBase):
             relation_name="dashboard-links",
             dashboard_links=[
                 DashboardLink(
-                    text="Tensorboards",
+                    text="TensorBoards",
                     link="/tensorboards/",
                     type="item",
                     icon="assessment",


### PR DESCRIPTION
Related to: https://github.com/canonical/kubeflow-dashboard-operator/issues/190

[Some of the links in the configmap ](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/manifests/base/configmap.yaml#L7)changed upstream. This PR resolves the changes related to this charm.