### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/candidate
           microk8s-addons: dns hostpath-storage ingress metallb:10.64.140.43-10.64.140.49
 
@@ -97,7 +97,7 @@ jobs:
         provider: microk8s
         channel: 1.25-strict/stable
         charmcraft-channel: latest/candidate
-        juju-channel: 3.5/stable
+        juju-channel: 3.4/stable
         microk8s-addons: dns hostpath-storage ingress metallb:10.64.140.43-10.64.140.49
 
     - name: Run test


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944