### PR TITLE
Add alert rules to tensorboard-controller based on the KF093 spec

### DIFF
--- a/charms/tensorboard-controller/src/prometheus_alert_rules/KubeflowTensorboardControllerServices.rules
+++ b/charms/tensorboard-controller/src/prometheus_alert_rules/KubeflowTensorboardControllerServices.rules
@@ -1,0 +1,24 @@
+groups:
+- name: KubeflowTensorboardControllerServices
+  rules:
+  - alert: KubeflowServiceDown
+    expr: up{} < 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "{{ $labels.juju_charm }} service is Down ({{ $labels.juju_model }}/{{ $labels.juju_unit }})"
+      description: |
+       One or more targets of {{ $labels.juju_charm }} charm are down on unit {{ $labels.juju_model }}/{{ $labels.juju_unit }}.
+       LABELS = {{ $labels }}
+
+  - alert: KubeflowServiceIsNotStable
+    expr: avg_over_time(up{}[10m]) < 0.5
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: "{{ $labels.juju_charm }} service is not stable ({{ $labels.juju_model }}/{{ $labels.juju_unit }})"
+      description: |
+        {{ $labels.juju_charm }} unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} has been unreachable at least 50% of the time over the last 10 minutes.
+        LABELS = {{ $labels }}


### PR DESCRIPTION
These alert rules provide an overview of all service states.

Using the KubeflowServiceDown or KubeflowServiceIsNotStable filter, the user
can easily see the status of all Kubeflow services.

part-of: [#1026](https://github.com/canonical/bundle-kubeflow/issues/1026)
