### PR TITLE
(backport) feat: add terraform modules for tensorboard controller and web-app charms

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -54,6 +54,22 @@ jobs:
     - name: Run unit tests
       run: tox -vve ${{ matrix.charm }}-unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    strategy:
+      matrix:
+        charm:
+          - tensorboard-controller
+          - tensorboards-web-app
+    with:
+      charm-path: ./charms/${{ matrix.charm }}
+      # Skipping the Terraform apply check as the tensorboard-controller goes to Waiting status
+      # instead of the expected Blocked or Active. This is currently a limitation of the
+      # Terraform re-usable workflows in canonical/charmed-kubeflow-workflows
+      # See https://github.com/canonical/charmed-kubeflow-workflows/issues/65
+      apply: false
+    
   integration:
     name: Charm-specific Integration tests (microk8s)
     runs-on: ubuntu-20.04

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,6 +64,7 @@ jobs:
           - tensorboards-web-app
     with:
       charm-path: ./charms/${{ matrix.charm }}
+      channel: "1.9/stable"
       # Skipping the Terraform apply check as the tensorboard-controller goes to Waiting status
       # instead of the expected Blocked or Active. This is currently a limitation of the
       # Terraform re-usable workflows in canonical/charmed-kubeflow-workflows

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__
 *.charm
 .idea
 .vscode
+venv/
+.terraform*
+*.tfstate*

--- a/charms/tensorboard-controller/terraform/README.md
+++ b/charms/tensorboard-controller/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for tensorboard-controller
+
+This is a Terraform module facilitating the deployment of the tensorboard-controller charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "tensorboard-controller" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "tensorboard-controller" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/tensorboard-controller/terraform/main.tf
+++ b/charms/tensorboard-controller/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "tensorboard_controller" {
+  charm {
+    name     = "tensorboard-controller"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/tensorboard-controller/terraform/outputs.tf
+++ b/charms/tensorboard-controller/terraform/outputs.tf
@@ -1,0 +1,16 @@
+output "app_name" {
+  value = juju_application.tensorboard_controller.name
+}
+
+output "provides" {
+  value = {
+    metrics_endpoint = "metrics-endpoint",
+  }
+}
+
+output "requires" {
+  value = {
+    gateway_info = "gateway-info",
+    logging      = "logging",
+  }
+}

--- a/charms/tensorboard-controller/terraform/variables.tf
+++ b/charms/tensorboard-controller/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.9/stable"
 }
 
 variable "config" {

--- a/charms/tensorboard-controller/terraform/variables.tf
+++ b/charms/tensorboard-controller/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "tensorboard-controller"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/tensorboard-controller/terraform/versions.tf
+++ b/charms/tensorboard-controller/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/tensorboard-controller/tox.ini
+++ b/charms/tensorboard-controller/tox.ini
@@ -79,3 +79,10 @@ commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration
 deps =
     -r requirements-integration.txt
 description = Run integration tests
+
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards

--- a/charms/tensorboards-web-app/terraform/README.md
+++ b/charms/tensorboards-web-app/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for tensorboards-web-app
+
+This is a Terraform module facilitating the deployment of the tensorboards-web-app charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "tensorboards-web-app" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "tensorboards-web-app" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/tensorboards-web-app/terraform/main.tf
+++ b/charms/tensorboards-web-app/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "tensorboards_web_app" {
+  charm {
+    name     = "tensorboards-web-app"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/tensorboards-web-app/terraform/outputs.tf
+++ b/charms/tensorboards-web-app/terraform/outputs.tf
@@ -1,0 +1,17 @@
+output "app_name" {
+  value = juju_application.tensorboards_web_app.name
+}
+
+output "provides" {
+  value = {
+    metrics_endpoint = "metrics-endpoint",
+  }
+}
+
+output "requires" {
+  value = {
+    ingress         = "ingress",
+    dashboard_links = "dashboard-links",
+    logging         = "logging",
+  }
+}

--- a/charms/tensorboards-web-app/terraform/variables.tf
+++ b/charms/tensorboards-web-app/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.9/stable"
 }
 
 variable "config" {

--- a/charms/tensorboards-web-app/terraform/variables.tf
+++ b/charms/tensorboards-web-app/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "tensorboards-web-app"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/tensorboards-web-app/terraform/versions.tf
+++ b/charms/tensorboards-web-app/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/tensorboards-web-app/tox.ini
+++ b/charms/tensorboards-web-app/tox.ini
@@ -79,3 +79,10 @@ commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration
 deps =
     -r requirements-integration.txt
 description = Run integration tests
+
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards


### PR DESCRIPTION
backports #142 to `track/1.9`
ref #140 and #141