### PR TITLE
remove charmcraft pin to latest/candidate

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -87,8 +87,6 @@ jobs:
           provider: microk8s
           channel: 1.31-strict/stable
           juju-channel: 3.6/stable
-          # TODO: remove after charmcraft 3.3 stable release
-          charmcraft-channel: latest/candidate
           microk8s-addons: dns hostpath-storage ingress metallb:10.64.140.43-10.64.140.49
 
       - run: |
@@ -113,8 +111,6 @@ jobs:
       with:
         provider: microk8s
         channel: 1.31-strict/stable
-        # TODO: remove after charmcraft 3.3 stable release
-        charmcraft-channel: latest/candidate
         juju-channel: 3.6/stable
         microk8s-addons: dns hostpath-storage ingress metallb:10.64.140.43-10.64.140.49
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,3 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate # TODO: change to 3.x/stable once the changes in edge are promoted


### PR DESCRIPTION
Removes the charmcraft channel pin now that charmcraft 3.3 is [released to stable](https://snapcraft.io/charmcraft)