### PR TITLE
fix: use charmcraft promote in promote.yaml workflow

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -21,7 +21,12 @@ jobs:
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:
-      - name: Release charm to channel
+      - name: Install charmcraft
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
-          charmcraft promote --name ${{ github.event.inputs.charm-name }} --from-channel ${{ github.event.inputs.origin-channel }} --to-channel ${{ github.event.inputs.destination-channel }}
+      - name: Run charmcraft promote
+        run: |
+          charmcraft promote --name ${{ github.event.inputs.charm-name }} \
+                              --from-channel ${{ github.event.inputs.origin-channel }} \
+                              --to-channel ${{ github.event.inputs.destination-channel }} \
+                              --yes

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -18,14 +18,10 @@ jobs:
   promote-charm:
     name: Promote charm
     runs-on: ubuntu-20.04
+    env:
+      CHARMCRAFT_AUTH=$(cat ${{ secrets.CHARMCRAFT_CREDENTIALS }})
     steps:
-      - uses: actions/checkout@v3
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.6.2
-        with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          destination-channel: ${{ github.event.inputs.destination-channel }}
-          origin-channel: ${{ github.event.inputs.origin-channel }}
-          tag-prefix: ${{ github.event.inputs.charm-name }}
-          charm-path: charms/${{ github.event.inputs.charm-name}}
+        run: |
+          sudo snap install charmcraft --channel latest/stable
+          charmcraft promote --name ${{ github.event.inputs.charm-name }} --from-channel ${{ github.event.inputs.origin-channel }} --to-channel ${{ github.event.inputs.destination-channel }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Promote charm
     runs-on: ubuntu-20.04
     env:
-      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }})
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:
       - name: Release charm to channel
         run: |

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Promote charm
     runs-on: ubuntu-20.04
     env:
-      CHARMCRAFT_AUTH=$(cat ${{ secrets.CHARMCRAFT_CREDENTIALS }})
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }})
     steps:
       - name: Release charm to channel
         run: |

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -23,5 +23,5 @@ jobs:
     steps:
       - name: Release charm to channel
         run: |
-          sudo snap install charmcraft --channel latest/stable
+          sudo snap install charmcraft --classic --channel latest/stable
           charmcraft promote --name ${{ github.event.inputs.charm-name }} --from-channel ${{ github.event.inputs.origin-channel }} --to-channel ${{ github.event.inputs.destination-channel }}


### PR DESCRIPTION
Ref https://github.com/canonical/bundle-kubeflow/issues/1202

Rewrites the promote.yaml workflow to use `charmcraft promote` command instead of the `release-charm` action. We can no longer use the `release-charm` action because it relies on having GH releases in the repo, which we have stopped producing since migrating  our CI to `data-platform-workflows`. See https://github.com/canonical/bundle-kubeflow/issues/1202 for more details.

Tested in [this test run](https://github.com/canonical/kubeflow-tensorboards-operator/actions/runs/13312024112/job/37176724874) by promoting the charm on a dummy track `0.0`. Note this track was opened for testing purposes and will be closed afterwards.