### PR TITLE
chore: upgrade to 1.10.0-rc.0

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   tensorboard-controller-image:
     type: oci-image
     description: OCI image for Tensorboard Controller
-    upstream-source: charmedkubeflow/tensorboard-controller:1.9.0-d74bfd2
+    upstream-source: docker.io/kubeflownotebookswg/tensorboard-controller:v1.10.0-rc.0
 requires:
   gateway-info:
     interface: istio-gateway-info

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for Tensorboards Web App
     auto-fetch: true
-    upstream-source: charmedkubeflow/tensorboards-web-app:1.9.0-4b44bb5
+    upstream-source: docker.io/kubeflownotebookswg/tensorboards-web-app:v1.9.0
 requires:
   ingress:
     interface: ingress

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for Tensorboards Web App
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/tensorboards-web-app:v1.9.0
+    upstream-source: docker.io/kubeflownotebookswg/tensorboards-web-app:v1.10.0-rc.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Upgrade using kf/manifests tag/v1.10.0-rc.1 (which corresponds to kf/kf 1.10.0-rc.0)
Regarding the TWA metrics, they will be enabled in a follow up PR similar to https://github.com/canonical/kubeflow-volumes-operator/pull/176, although we still need to discuss a bit more. 

Close https://warthogs.atlassian.net/browse/KF-6858