### PR TITLE
chore: integrate 1.10.0-rc.1 rocks

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   tensorboard-controller-image:
     type: oci-image
     description: OCI image for Tensorboard Controller
-    upstream-source: docker.io/charmedkubeflow/tensorboard-controller:1.10.0-rc.0-8f3a822
+    upstream-source: docker.io/charmedkubeflow/tensorboard-controller:1.10.0-rc.1-ad16c8b
 requires:
   gateway-info:
     interface: istio-gateway-info

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for Tensorboards Web App
     auto-fetch: true
-    upstream-source: docker.io/charmedkubeflow/tensorboards-web-app:1.10.0-rc.0-9e97f18
+    upstream-source: docker.io/charmedkubeflow/tensorboards-web-app:1.10.0-rc.1-b7c558b
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Integrate 1.10.0-rc.1 rocks in preparation for a new release.

Fixes #172 

The only changes introduced in Kubeflow 1.10.0-rc.2 were image updates, thus we just need to integrate the rocks for version 1.10.0-rc.1 of the tensorboard components according to https://github.com/kubeflow/manifests/pull/3008.