### PR TITLE
chore: Update Ubuntu base in CI from 20.04 to 24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,7 +158,7 @@ jobs:
           merge-multiple: true
 
       - run: |
-          tox -vve ${{ matrix.charm }}-integration -- --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
+          tox -vve ${{ matrix.charm }}-integration -- --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@20.04-amd64.charm
 
       # Collect debug logs if failed
       - name: Dump Juju/K8s logs on failure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,34 +53,44 @@ jobs:
 
   lint:
     name: Lint Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         charm: [tensorboard-controller, tensorboards-web-app]
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
 
     - name: Install dependencies
-      run: sudo apt install tox
+      run: pip install tox
 
     - name: Lint code
       run: tox -vve ${{ matrix.charm }}-lint
 
   unit:
     name: Unit Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         charm: [tensorboard-controller, tensorboards-web-app]
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
 
     - name: Install dependencies
-      run: sudo apt install tox
+      run: pip install tox
 
     - name: Run unit tests
       run: tox -vve ${{ matrix.charm }}-unit
@@ -115,7 +125,7 @@ jobs:
   integration:
     name: Integration tests (microk8s)
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -124,6 +134,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
+          
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -142,7 +158,7 @@ jobs:
           merge-multiple: true
 
       - run: |
-          sg snap_microk8s -c "tox -vve ${{ matrix.charm }}-integration -- --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@20.04-amd64.charm"
+          tox -vve ${{ matrix.charm }}-integration -- --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
       # Collect debug logs if failed
       - name: Dump Juju/K8s logs on failure
@@ -155,10 +171,16 @@ jobs:
   deploy:
     name: Integration Test
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
+    
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:


### PR DESCRIPTION
Closes #175 

This PR updates all Ubuntu bases from `20.04` to `24.04`. Note that we also setup Python version `3.8`, which is what we currently use to pack the charms