### PR TITLE
chore: integrate tensorboards rocks 1.10.0

### DIFF
--- a/charms/tensorboard-controller/metadata.yaml
+++ b/charms/tensorboard-controller/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   tensorboard-controller-image:
     type: oci-image
     description: OCI image for Tensorboard Controller
-    upstream-source: docker.io/charmedkubeflow/tensorboard-controller:1.10.0-rc.1-ad16c8b
+    upstream-source: docker.io/charmedkubeflow/tensorboard-controller:1.10.0-43d993e
 requires:
   gateway-info:
     interface: istio-gateway-info

--- a/charms/tensorboards-web-app/metadata.yaml
+++ b/charms/tensorboards-web-app/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for Tensorboards Web App
     auto-fetch: true
-    upstream-source: docker.io/charmedkubeflow/tensorboards-web-app:1.10.0-rc.1-b7c558b
+    upstream-source: docker.io/charmedkubeflow/tensorboards-web-app:1.10.0-43d993e
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7145


The only changes introduced in Kubeflow 1.10.0-rc.3 were image updates, thus we just need to integrate the rocks for version 1.10.0 of the tensorboard components according to https://github.com/kubeflow/manifests/pull/3071.

Note that enabling the metrics will be handled in #173 