### PR TITLE
cherry-pick(fix): set constraints to setuptools-scm to avoid install loops from #187

### DIFF
--- a/charms/tensorboard-controller/charmcraft.yaml
+++ b/charms/tensorboard-controller/charmcraft.yaml
@@ -38,6 +38,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/tensorboard-controller/constraints.txt
+++ b/charms/tensorboard-controller/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/tensorboards-web-app/charmcraft.yaml
+++ b/charms/tensorboards-web-app/charmcraft.yaml
@@ -38,6 +38,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/tensorboards-web-app/constraints.txt
+++ b/charms/tensorboards-web-app/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"


### PR DESCRIPTION
Due to python/importlib_metadata#516, we need to set up constaints to the `setuptools-scm` to avoid install loops for these charms dependencies, as recommended by the charmcraft team (see https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428).

Fixes #184