### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/charms/tensorboard-controller/requirements-integration.txt
+++ b/charms/tensorboard-controller/requirements-integration.txt
@@ -26,7 +26,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -47,7 +47,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/tensorboard-controller/requirements-integration.txt
+++ b/charms/tensorboard-controller/requirements-integration.txt
@@ -26,7 +26,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.9
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests

--- a/charms/tensorboard-controller/requirements-unit.txt
+++ b/charms/tensorboard-controller/requirements-unit.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -43,7 +43,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/tensorboard-controller/requirements.in
+++ b/charms/tensorboard-controller/requirements.in
@@ -1,7 +1,8 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-charmed-kubeflow-chisme
+# Pin charmed-kubeflow-chisme due to
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11
 lightkube
 ops
 # from loki_k8s.v1.loki_push_api.py

--- a/charms/tensorboard-controller/requirements.txt
+++ b/charms/tensorboard-controller/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -41,7 +41,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/tensorboard-controller/src/charm.py
+++ b/charms/tensorboard-controller/src/charm.py
@@ -15,9 +15,9 @@ from charms.istio_pilot.v0.istio_gateway_info import GatewayRelationError, Gatew
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from lightkube.models.core_v1 import ServicePort
 from lightkube import ApiError
 from lightkube.generic_resource import load_in_cluster_generic_resources
+from lightkube.models.core_v1 import ServicePort
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.rbac_authorization_v1 import ClusterRole, ClusterRoleBinding
 from ops import main

--- a/charms/tensorboard-controller/tests/integration/charms_dependencies.py
+++ b/charms/tensorboard-controller/tests/integration/charms_dependencies.py
@@ -1,0 +1,13 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+ISTIO_GATEWAY = CharmSpec(
+    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+)
+ISTIO_PILOT = CharmSpec(
+    charm="istio-pilot",
+    channel="latest/edge",
+    config={"default-gateway": "test-gateway"},
+    trust=True,
+)

--- a/charms/tensorboard-controller/tests/integration/test_charm.py
+++ b/charms/tensorboard-controller/tests/integration/test_charm.py
@@ -14,6 +14,7 @@ from charmed_kubeflow_chisme.testing import (
     deploy_and_assert_grafana_agent,
     get_alert_rules,
 )
+from charms_dependencies import ISTIO_GATEWAY, ISTIO_PILOT
 from lightkube import ApiError, Client, codecs
 from lightkube.generic_resource import (
     create_namespaced_resource,
@@ -42,8 +43,7 @@ TENSORBOARD_RESOURCE = create_namespaced_resource(
     plural="tensorboards",
 )
 
-ISTIO_GATEWAY = "istio-ingressgateway"
-ISTIO_PILOT = "istio-pilot"
+ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
 
 
 @pytest.fixture(scope="module")
@@ -109,7 +109,7 @@ async def test_istio_gateway_info_relation(ops_test: OpsTest):
     await setup_istio(ops_test, ISTIO_GATEWAY, ISTIO_PILOT)
 
     # add Tensorboard-Controller/Istio relation
-    await ops_test.model.integrate(f"{ISTIO_PILOT}:gateway-info", f"{APP_NAME}:gateway-info")
+    await ops_test.model.integrate(f"{ISTIO_PILOT.charm}:gateway-info", f"{APP_NAME}:gateway-info")
 
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 5

--- a/charms/tensorboard-controller/tests/integration/utils.py
+++ b/charms/tensorboard-controller/tests/integration/utils.py
@@ -4,6 +4,7 @@
 import logging
 
 import tenacity
+from charmed_kubeflow_chisme.testing import CharmSpec
 from lightkube import Client
 from lightkube.core.resource import Resource
 from pytest_operator.plugin import OpsTest
@@ -11,25 +12,24 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-async def setup_istio(ops_test: OpsTest, istio_gateway: str, istio_pilot: str):
+async def setup_istio(ops_test: OpsTest, istio_gateway: CharmSpec, istio_pilot: CharmSpec):
     """Deploy Istio Ingress Gateway and Istio Pilot."""
     await ops_test.model.deploy(
-        entity_url="istio-gateway",
-        application_name=istio_gateway,
-        channel="latest/edge",
-        config={"kind": "ingress"},
-        trust=True,
+        entity_url=istio_gateway.charm,
+        channel=istio_gateway.channel,
+        config=istio_gateway.config,
+        trust=istio_gateway.trust,
     )
     await ops_test.model.deploy(
-        istio_pilot,
-        channel="latest/edge",
-        config={"default-gateway": "test-gateway"},
-        trust=True,
+        istio_pilot.charm,
+        channel=istio_pilot.channel,
+        config=istio_pilot.config,
+        trust=istio_pilot.trust,
     )
-    await ops_test.model.add_relation(istio_pilot, istio_gateway)
+    await ops_test.model.add_relation(istio_pilot.charm, istio_gateway.charm)
 
     await ops_test.model.wait_for_idle(
-        apps=[istio_pilot, istio_gateway],
+        apps=[istio_pilot.charm, istio_gateway.charm],
         status="active",
         raise_on_blocked=False,
         timeout=60 * 20,

--- a/charms/tensorboards-web-app/requirements-integration.txt
+++ b/charms/tensorboards-web-app/requirements-integration.txt
@@ -34,7 +34,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.9
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests

--- a/charms/tensorboards-web-app/requirements-integration.txt
+++ b/charms/tensorboards-web-app/requirements-integration.txt
@@ -34,7 +34,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -59,7 +59,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/tensorboards-web-app/requirements-unit.txt
+++ b/charms/tensorboards-web-app/requirements-unit.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -43,7 +43,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/tensorboards-web-app/requirements.in
+++ b/charms/tensorboards-web-app/requirements.in
@@ -3,7 +3,9 @@
 
 ops
 oci-image
-charmed-kubeflow-chisme
+# Pin charmed-kubeflow-chisme due to
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11
 lightkube
 serialized-data-interface
 # from loki_k8s.v1.loki_push_api.py

--- a/charms/tensorboards-web-app/requirements.txt
+++ b/charms/tensorboards-web-app/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -41,7 +41,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -5,28 +5,28 @@
 """A Juju Charm for Tensorboards Web App."""
 
 import logging
-from typing import Dict
 from pathlib import Path
-import yaml
+from typing import Dict
 
+import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
-from charms.kubeflow_dashboard.v0.kubeflow_dashboard_links import (
-    DashboardLink,
-    KubeflowDashboardLinksRequirer,
-)
 from charmed_kubeflow_chisme.kubernetes import (
     KubernetesResourceHandler,
     create_charm_default_labels,
 )
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charmed_kubeflow_chisme.pebble import update_layer
+from charms.kubeflow_dashboard.v0.kubeflow_dashboard_links import (
+    DashboardLink,
+    KubeflowDashboardLinksRequirer,
+)
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from lightkube import ApiError
 from lightkube.generic_resource import load_in_cluster_generic_resources
 from lightkube.models.core_v1 import ServicePort
-from lightkube.resources.rbac_authorization_v1 import ClusterRole, ClusterRoleBinding
 from lightkube.resources.core_v1 import ServiceAccount
+from lightkube.resources.rbac_authorization_v1 import ClusterRole, ClusterRoleBinding
 from ops import main
 from ops.charm import CharmBase
 from ops.model import ActiveStatus, BlockedStatus, Container, MaintenanceStatus, WaitingStatus

--- a/charms/tensorboards-web-app/tests/integration/charms_dependencies.py
+++ b/charms/tensorboards-web-app/tests/integration/charms_dependencies.py
@@ -1,0 +1,13 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+ISTIO_GATEWAY = CharmSpec(
+    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+)
+ISTIO_PILOT = CharmSpec(
+    charm="istio-pilot",
+    channel="latest/edge",
+    config={"default-gateway": "test-gateway"},
+    trust=True,
+)

--- a/charms/tensorboards-web-app/tests/integration/test_charm.py
+++ b/charms/tensorboards-web-app/tests/integration/test_charm.py
@@ -108,7 +108,7 @@ async def setup_istio(ops_test: OpsTest, istio_gateway: CharmSpec, istio_pilot: 
         apps=[istio_pilot.charm, istio_gateway.charm],
         status="active",
         raise_on_blocked=False,
-        timeout=60 * 20,
+        timeout=60 * 5,
     )
 
 

--- a/charms/tensorboards-web-app/tests/integration/test_charm.py
+++ b/charms/tensorboards-web-app/tests/integration/test_charm.py
@@ -107,7 +107,6 @@ async def setup_istio(ops_test: OpsTest, istio_gateway: CharmSpec, istio_pilot: 
     await ops_test.model.wait_for_idle(
         apps=[istio_pilot.charm, istio_gateway.charm],
         status="active",
-        raise_on_blocked=False,
         timeout=60 * 5,
     )
 


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
