### PR TITLE
fix: set correct name for track output in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ on:
         value: ${{ jobs.get-charm-paths-track.outputs.charm-paths }}
       track:
         description: Charmhub track determined from branch name
-        value: ${{ jobs.get-charm-paths-track.outputs.charm-channel }}
+        value: ${{ jobs.get-charm-paths-track.outputs.track }}
 
 jobs:
   get-charm-paths-track:


### PR DESCRIPTION
Introduced in #220
The output name should be `track` rather than the deprecated `charm-channel`. See [failure](https://github.com/canonical/kubeflow-tensorboards-operator/actions/runs/19961620438/job/57244647919).