### PR TITLE
fix: Don't run CI tests multiple times

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -2,8 +2,6 @@ name: On Pull Request
 
 # On pull_request, we:
 # * create backport labels if it is against main, only when the PR is opened/reopened
-# * always publish to charmhub at latest/edge/branchname
-# * always run tests
 
 on:
   pull_request:
@@ -18,14 +16,3 @@ jobs:
     with:
       track_file_path: ".github/automatic_backport_tracks.yaml"
       label_prefix: "backport "
-
-  tests:
-    name: Run Tests
-    uses: ./.github/workflows/integrate.yaml
-    secrets: inherit
-
-  # publish runs in parallel with tests, as we always publish in this situation
-  publish-charm:
-    name: Publish Charm
-    uses: ./.github/workflows/publish.yaml
-    secrets: inherit


### PR DESCRIPTION
This PR updated `on_pull_request.yaml` to only run the `populate-labels` action. Since this repository already has `ci.yaml`, we don't actually want to run the CI tests multiple times. 

