### PR TITLE
chore: pin charm dependencies in tests (track/1.11)

### DIFF
--- a/charms/tensorboard-controller/tests/integration/charms_dependencies.py
+++ b/charms/tensorboard-controller/tests/integration/charms_dependencies.py
@@ -3,11 +3,11 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/edge", config={"kind": "ingress"}, trust=True
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="latest/edge",
+    channel="1.28/edge",
     config={"default-gateway": "test-gateway"},
     trust=True,
 )

--- a/charms/tensorboards-web-app/tests/integration/charms_dependencies.py
+++ b/charms/tensorboards-web-app/tests/integration/charms_dependencies.py
@@ -3,11 +3,11 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/edge", config={"kind": "ingress"}, trust=True
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="latest/edge",
+    channel="1.28/edge",
     config={"default-gateway": "test-gateway"},
     trust=True,
 )


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11 — fallback, no Solutions branch references this charm-repo track)
- `istio-gateway`: `latest/edge` → `1.28/edge`
- `istio-pilot`: `latest/edge` → `1.28/edge`

Refs: canonical/bundle-kubeflow#1379
