### PR TITLE
fix: handle multiple `istio-ingress-route` relations 

### DIFF
--- a/charms/tensorboards-web-app/poetry.lock
+++ b/charms/tensorboards-web-app/poetry.lock
@@ -3391,4 +3391,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "0d7e21067af0b2bda85d86c00557043af5e0c88b4f8c898234c04af64983898c"
+content-hash = "d4bd7769b8f874bca80e781b605e3da24b9aeedc431d1665d786871d64b89a0b"

--- a/charms/tensorboards-web-app/pyproject.toml
+++ b/charms/tensorboards-web-app/pyproject.toml
@@ -99,6 +99,7 @@ aiohttp = "^3.10.11"
 pytest = "^8.3.4"
 pytest-operator = "^0.38.0"
 pyyaml = "^6.0.2"
+tenacity = "^9.0.0"
 
 [project]
 name = "kubeflow-tensorboards-operator"

--- a/charms/tensorboards-web-app/src/charm.py
+++ b/charms/tensorboards-web-app/src/charm.py
@@ -216,14 +216,26 @@ class TensorboardsWebApp(CharmBase):
             ],
         )
 
+        # submit_config publishes this same config to every istio-ingress-route
+        # relation, so all related ingress providers are (re)configured at once.
         self.ingress.submit_config(config)
 
     def _check_istio_relations(self):
-        """Check that both ambient and sidecar relations are not present simultaneously."""
-        ambient_relation = self.model.get_relation("istio-ingress-route")
-        sidecar_relation = self.model.get_relation("ingress")
+        """Validate the charm's ingress relations are mutually exclusive.
 
-        if ambient_relation and sidecar_relation:
+        The charm supports both ambient ingress (via the 'istio-ingress-route'
+        endpoint) and sidecar ingress (via the 'ingress' endpoint), but the two
+        cannot be used at the same time. Each endpoint may hold any number of relations,
+        so this inspects the full list of relations on each endpoint.
+
+        Raises:
+            ErrorWithStatus: with BlockedStatus if relations exist on both endpoints,
+                or if neither endpoint has any relation.
+        """
+        ambient_relations = self.model.relations["istio-ingress-route"]
+        sidecar_relations = self.model.relations["ingress"]
+
+        if ambient_relations and sidecar_relations:
             self.logger.error(
                 "Both 'istio-ingress-route' and 'ingress' relations are present, "
                 "remove one to unblock."
@@ -234,7 +246,7 @@ class TensorboardsWebApp(CharmBase):
                 BlockedStatus,
             )
 
-        if not ambient_relation and not sidecar_relation:
+        if not ambient_relations and not sidecar_relations:
             self.logger.error(
                 "None of 'istio-ingress-route' or 'ingress' relations are present, please relate one."
             )

--- a/charms/tensorboards-web-app/tests/integration/test_charm_ambient.py
+++ b/charms/tensorboards-web-app/tests/integration/test_charm_ambient.py
@@ -5,8 +5,11 @@ import logging
 from pathlib import Path
 
 import pytest
+import tenacity
 import yaml
 from charmed_kubeflow_chisme.testing import (
+    ISTIO_INGRESS_K8S_APP,
+    ISTIO_INGRESS_ROUTE_ENDPOINT,
     assert_logging,
     assert_path_reachable_through_ingress,
     assert_security_context,
@@ -16,6 +19,7 @@ from charmed_kubeflow_chisme.testing import (
     get_pod_names,
 )
 from lightkube import Client
+from lightkube.generic_resource import create_namespaced_resource
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -27,6 +31,28 @@ CONTAINERS_SECURITY_CONTEXT_MAP = generate_container_securitycontext_map(METADAT
 HTTP_PATH = "/tensorboards/"
 HEADERS = {"kubeflow-userid": "test"}
 EXPECTED_RESPONSE_TEXT = "Tensorboards Manager UI"
+
+# A second istio-ingress-k8s instance used to verify multiple-ingress support.
+SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
+INGRESS_CHANNEL = "2/stable"
+# Name of the HTTPRoute submitted by tensorboards-web-app (see charm._ambient_mesh_ingress).
+INGRESS_ROUTE_NAME = "http-ingress"
+# Gateway listener section for cleartext HTTP on port 80.
+HTTP_SECTION_NAME = "http-80"
+# Path matched by the tensorboards-web-app HTTPRoute.
+INGRESS_ROUTE_PATH = HTTP_PATH
+# Gateway API generic resources, resolved at runtime via lightkube.
+HTTPROUTE_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
+)
+GATEWAY_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "Gateway", "gateways"
+)
+RETRY_120_SECONDS = tenacity.Retrying(
+    stop=tenacity.stop_after_delay(120),
+    wait=tenacity.wait_fixed(2),
+    reraise=True,
+)
 
 
 @pytest.fixture(scope="session")
@@ -74,6 +100,11 @@ async def test_logging(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_ui_is_accessible(ops_test: OpsTest):
+    """Verify that UI is accessible through the ingress gateway before the second ingress."""
+    await assert_ui_is_accessible(ops_test)
+
+
+async def assert_ui_is_accessible(ops_test: OpsTest):
     """Verify that UI is accessible through the ingress gateway."""
     await assert_path_reachable_through_ingress(
         http_path=HTTP_PATH,
@@ -104,3 +135,84 @@ async def test_container_security_context(
         CONTAINERS_SECURITY_CONTEXT_MAP,
         ops_test.model.name,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_and_relate_second_ingress(ops_test: OpsTest):
+    """Deploy a second istio-ingress-k8s and relate it to tensorboards-web-app.
+
+    tensorboards-web-app must accept more than one istio-ingress-route relation without
+    erroring, so it should remain active after the second ingress is related.
+    """
+    await ops_test.model.deploy(
+        ISTIO_INGRESS_K8S_APP,
+        application_name=SECOND_INGRESS_APP,
+        channel=INGRESS_CHANNEL,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        [SECOND_INGRESS_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=60 * 15,
+    )
+
+    await ops_test.model.integrate(
+        f"{SECOND_INGRESS_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        f"{APP_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+    )
+    await ops_test.model.wait_for_idle(
+        [APP_NAME, SECOND_INGRESS_APP],
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=False,
+        timeout=60 * 10,
+        idle_period=30,
+    )
+
+    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+
+async def test_httproute_attached_to_second_gateway(ops_test: OpsTest, lightkube_client: Client):
+    """Verify the HTTPRoute for the second ingress is created and bound to its Gateway.
+
+    The istio-ingress-k8s charm names each route
+    ``{source_app}-{route_name}-httproute-{section}-{ingress_app}`` and binds it to a
+    Gateway named after the ingress application via ``parentRefs``. We assert that the
+    route created for the second ingress is attached to the *second* Gateway (not the
+    first) and routes the tensorboards-web-app path to the tensorboards-web-app backend.
+    """
+    namespace = ops_test.model_name
+
+    expected_route_name = (
+        f"{APP_NAME}-{INGRESS_ROUTE_NAME}-httproute-{HTTP_SECTION_NAME}-{SECOND_INGRESS_APP}"
+    )
+
+    # The second Gateway should exist, named after the second ingress application.
+    lightkube_client.get(GATEWAY_RESOURCE, name=SECOND_INGRESS_APP, namespace=namespace)
+
+    # Retry to give the ingress charm time to reconcile the HTTPRoute resources.
+    httproute = None
+    for attempt in RETRY_120_SECONDS:
+        with attempt:
+            httproute = lightkube_client.get(
+                HTTPROUTE_RESOURCE, name=expected_route_name, namespace=namespace
+            )
+
+    parent_refs = httproute.spec["parentRefs"]
+    assert len(parent_refs) == 1
+    # The route must be attached to the SECOND gateway, not the first.
+    assert parent_refs[0]["name"] == SECOND_INGRESS_APP
+    assert parent_refs[0]["sectionName"] == HTTP_SECTION_NAME
+
+    # And it must route the tensorboards-web-app path to the tensorboards-web-app backend.
+    rule = httproute.spec["rules"][0]
+    assert rule["matches"][0]["path"]["value"] == INGRESS_ROUTE_PATH
+    assert rule["backendRefs"][0]["name"] == APP_NAME
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible_after_second_ingress(ops_test: OpsTest):
+    """Verify that UI is still accessible through the ingress gateway after the second ingress."""
+    await assert_ui_is_accessible(ops_test)

--- a/charms/tensorboards-web-app/tests/unit/test_operator.py
+++ b/charms/tensorboards-web-app/tests/unit/test_operator.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import yaml
-from charms.istio_ingress_k8s.v0.istio_ingress_route import ProtocolType
+from charms.istio_ingress_k8s.v0.istio_ingress_route import (
+    HTTPPathMatchType,
+    IstioIngressRouteConfig,
+    ProtocolType,
+)
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
@@ -12,6 +16,13 @@ from charm import TensorboardsWebApp
 
 APP_NAME = "tensorboards-web-app"
 PORT = 5000
+ISTIO_INGRESS_ROUTE_RELATION = "istio-ingress-route"
+INGRESS_RELATION = "ingress"
+ISTIO_INGRESS_K8S_APP = "istio-ingress-k8s"
+SECOND_ISTIO_INGRESS_K8S_APP = f"{ISTIO_INGRESS_K8S_APP}-2"
+ISTIO_PILOT_APP = "istio-pilot"
+HTTP_PATH = "/tensorboards/"
+HTTP_SECTION_NAME = "http-80"
 
 
 @pytest.fixture(scope="function")
@@ -114,9 +125,9 @@ class TestCharm:
     ):
         """Test the charm is in BlockedStatus when both sidecar and ambient relations are added."""
         # Arrange
-        harness.add_relation("ingress", "istio-pilot")
+        harness.add_relation(INGRESS_RELATION, ISTIO_PILOT_APP)
 
-        harness.add_relation("istio-ingress-route", "istio-ingress-k8s")
+        harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, ISTIO_INGRESS_K8S_APP)
 
         # Act
         harness.begin_with_initial_hooks()
@@ -134,8 +145,8 @@ class TestCharm:
     ):
         """Test that multiple istio-ingress-route relations are handled without erroring."""
         # Arrange
-        harness.add_relation("istio-ingress-route", "istio-ingress-k8s")
-        harness.add_relation("istio-ingress-route", "istio-ingress-k8s-2")
+        harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, ISTIO_INGRESS_K8S_APP)
+        harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, SECOND_ISTIO_INGRESS_K8S_APP)
 
         # Act
         harness.begin_with_initial_hooks()
@@ -143,6 +154,37 @@ class TestCharm:
         # Assert: with only ambient relations and no conflicting sidecar relation,
         # the charm is configured for every ambient relation and becomes active.
         assert isinstance(harness.charm.model.unit.status, ActiveStatus)
+
+    @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
+    @patch("charm.TensorboardsWebApp.k8s_resource_handler")
+    def test_each_istio_ingress_route_relation_receives_config(
+        self, k8s_resource_handler: MagicMock, harness: Harness
+    ):
+        """Test that an HTTPRoute config is submitted to every istio-ingress-route relation."""
+        # Arrange
+        rel_id_1 = harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, ISTIO_INGRESS_K8S_APP)
+        rel_id_2 = harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, SECOND_ISTIO_INGRESS_K8S_APP)
+
+        # Act
+        harness.begin_with_initial_hooks()
+
+        # Assert
+        # Each relation's application databag should contain a valid config that
+        # defines the tensorboards-web-app HTTPRoute, proving the lib handles every ingress.
+        for rel_id in (rel_id_1, rel_id_2):
+            app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
+            assert "config" in app_data
+
+            config = IstioIngressRouteConfig.model_validate_json(app_data["config"])
+            assert len(config.http_routes) == 1
+            http_route = config.http_routes[0]
+            assert http_route.matches[0].path.type == HTTPPathMatchType.PathPrefix
+            assert http_route.matches[0].path.value == HTTP_PATH
+            assert http_route.backends[0].service == harness.charm.app.name
+            assert http_route.backends[0].port == PORT
+            # The route's parent (the Gateway listener referenced under parentRefs in
+            # the HTTPRouteSpec) should be the expected HTTP listener.
+            assert http_route.listener.name == HTTP_SECTION_NAME
 
     @pytest.mark.parametrize("tls_enabled, expected_port", [(False, 80), (True, 443)])
     @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)

--- a/charms/tensorboards-web-app/tests/unit/test_operator.py
+++ b/charms/tensorboards-web-app/tests/unit/test_operator.py
@@ -127,6 +127,23 @@ class TestCharm:
             BlockedStatus,
         )
 
+    @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
+    @patch("charm.TensorboardsWebApp.k8s_resource_handler")
+    def test_multiple_ambient_relations_added(
+        self, k8s_resource_handler: MagicMock, harness: Harness
+    ):
+        """Test that multiple istio-ingress-route relations are handled without erroring."""
+        # Arrange
+        harness.add_relation("istio-ingress-route", "istio-ingress-k8s")
+        harness.add_relation("istio-ingress-route", "istio-ingress-k8s-2")
+
+        # Act
+        harness.begin_with_initial_hooks()
+
+        # Assert: with only ambient relations and no conflicting sidecar relation,
+        # the charm is configured for every ambient relation and becomes active.
+        assert isinstance(harness.charm.model.unit.status, ActiveStatus)
+
     @pytest.mark.parametrize("tls_enabled, expected_port", [(False, 80), (True, 443)])
     @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
     @patch("charm.TensorboardsWebApp.k8s_resource_handler", MagicMock)

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -13,7 +13,7 @@ providers:
       load-balancer:
         enabled: true
         l2-mode: true
-        cidrs: 10.64.140.43/32
+        cidrs: 10.64.140.42/31  # NOTE: at least two IPs required for integration tests: one for each of the two Istio ingress gateways
     bootstrap-constraints:
       root-disk: 2G
 


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1446

Use `model.relations[...]` instead of `model.get_relation(...)` when checking ingress relations, so the charm no longer raises `TooManyRelatedAppsError` when more than one `istio-ingress-route` relation is present.

Add unit tests covering multiple `istio-ingress-route` relations and verifying each relation receives a valid `HTTPRoute` config.

_Note: this PR was created with the help of AI_